### PR TITLE
Fix root url pattern

### DIFF
--- a/propalyzer_site/propalyzer_site/urls.py
+++ b/propalyzer_site/propalyzer_site/urls.py
@@ -20,6 +20,7 @@ from django.contrib import admin
 # from ..propalyzer_app.forms import BootstrapAuthenticationForm
 
 urlpatterns = [
+	url(r'^$', include('propalyzer_app.urls')),
 	url(r'^propalyzer/', include('propalyzer_app.urls')),
 	url(r'^admin/', admin.site.urls),
 	url(r'^accounts/', include('propalyzer_app.urls'))


### PR DESCRIPTION
Happy Hacktoberfest. I was reading over your repo and saw some low-hanging fruit while trying to get the app running on localhost. It doesn't actually have a view for `localhost:8000` and instead has an error page, which this fixes.