### PR TITLE
interface_and_readme_changes_1

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ $ python manage.py createsuperuser
 
 - To run the local server, type the command below from the same directory as your "manage.py" file ("python manage.py runserver" is disabled to let Gunicorn handle static file collection)
 ```
-> gunicorn wsgi
+$ gunicorn wsgi
 ```
 Test that the site homepage appears when you browse to http://127.0.0.1:8000.
 

--- a/propalyzer_site/propalyzer_app/templates/app/address.html
+++ b/propalyzer_site/propalyzer_app/templates/app/address.html
@@ -5,7 +5,7 @@
 
 <div class="pricing-header bg-info px-3 py-3 pt-md-5 pb-md-4 mx-auto text-center">
 	<h1 class="display-4">Start Here...</h1>
-	<p class="lead">Enter the residential property address to get the following details:</p>
+	<p class="lead">Enter a residential property address to get the following details:</p>
 </div>
 <div class="bg-light text-dark px-5 py-3 pt-md-5 pb-md-4">
 	<div class="row">
@@ -35,6 +35,7 @@
 	<div class="row align-content-center text-center">
 		<div class="col-2"></div>
 		<div class="col-md-8">
+        <p class="search_instruction">Use the following format for address:<br><i> 3465 N Main St, Soquel, CA 95073</i></p>
 			<form method="POST">
 				{% csrf_token %}
 				{{ form|crispy }}


### PR DESCRIPTION
Made a couple minor edits to the app's user interface and readme, notably the inclusion of an example input before submission for clarity. Also changed a confusing ">" symbol inside the "> gunicorn wsgi" example command of the macOS installation instructions to a "$" in keeping with the previous macOS command examples.